### PR TITLE
Fix missing header and allow for char*

### DIFF
--- a/flecsi/data/CMakeLists.txt
+++ b/flecsi/data/CMakeLists.txt
@@ -13,6 +13,7 @@
 #~----------------------------------------------------------------------------~#
 
 set(data_HEADERS
+  data_client.h
   data_constants.h
   data.h
   default_meta_data.h

--- a/flecsi/utils/const_string.h
+++ b/flecsi/utils/const_string.h
@@ -22,6 +22,7 @@
  */
 
 #include <limits>
+#include <cstring>
 
 #include "hash.h"
 
@@ -40,6 +41,11 @@ class const_string_t
   template <hash_type_t N>
   constexpr const_string_t(const char(&str)[N])
       : str_(str), size_(N - 1)
+  {
+  }
+
+  constexpr const_string_t(const char* str)
+      : str_(str), size_(strlen(str))
   {
   }
 


### PR DESCRIPTION
We want the char* constructor for use in portage for variable names.