### PR TITLE
More changes that got lost when the master branch changed.

### DIFF
--- a/flecsi/data/data_client.cc
+++ b/flecsi/data/data_client.cc
@@ -28,6 +28,8 @@ data_client_t & data_client_t::operator=(data_client_t && o)
   auto rid = o.runtime_id();
   // move the data now
   flecsi::data::storage_t::instance().move( rid, runtime_id() );
+  // return a reference to the new object
+  return *this;
 }
 
 data_client_t::~data_client_t() 

--- a/flecsi/data/old/default_storage_policy.h
+++ b/flecsi/data/old/default_storage_policy.h
@@ -391,7 +391,7 @@ class default_data_storage_policy_t
      */
     global_accessor_t(const std::string & label, const size_t size, T * data,
         const user_meta_data_t & meta)
-        : label_(label), size_(1), data_(data), meta_(meta), is_(1)
+        : label_(label), size_(1), data_(data), meta_(&meta), is_(1)
     {
     }
 
@@ -520,14 +520,14 @@ class default_data_storage_policy_t
 
       \return The user meta data.
      */
-    const user_meta_data_t & meta() const { return meta_; }
+    const user_meta_data_t & meta() const { return *meta_; }
 
    private:
 
     std::string label_ = "";
     size_t size_ = 0;
     T * data_ = nullptr;
-    const user_meta_data_t & meta_ = user_meta_data_t();
+    const user_meta_data_t * meta_ = nullptr;
     index_space_t is_;
 
   }; // struct global_accessor_t
@@ -567,7 +567,7 @@ class default_data_storage_policy_t
      */
     dense_accessor_t(const std::string & label, const size_t size, T * data,
         const user_meta_data_t & meta)
-        : label_(label), size_(size), data_(data), meta_(meta), is_(size_)
+        : label_(label), size_(size), data_(data), meta_(&meta), is_(size_)
     {
     }
 
@@ -670,7 +670,7 @@ class default_data_storage_policy_t
 
       \return The user meta data.
      */
-    const user_meta_data_t & meta() const { return meta_; }
+    const user_meta_data_t & meta() const { return *meta_; }
 
     /*!
       \brief Return an iterator to the beginning of this data data.
@@ -697,7 +697,7 @@ class default_data_storage_policy_t
     std::string label_ = "";
     size_t size_ = 0;
     T * data_ = nullptr;
-    const user_meta_data_t & meta_ = user_meta_data_t();
+    const user_meta_data_t * meta_ = nullptr;
     index_space_t is_;
 
   }; // struct dense_accessor_t

--- a/flecsi/topology/mesh_types.h
+++ b/flecsi/topology/mesh_types.h
@@ -789,6 +789,8 @@ public:
   {
     // call base_t move operator
     data::data_client_t::operator=(std::move(o));
+    // return a reference to the object
+    return *this;
   };
 
 

--- a/flecsi/utils/id.h
+++ b/flecsi/utils/id.h
@@ -96,7 +96,11 @@ namespace flecsi
 
     local_id_t local_id() const
     {
-      return *reinterpret_cast<const local_id_t*>(this);
+      local_id_t r = dimension_;
+      r |= local_id_t(domain_) << 2; 
+      r |= local_id_t(partition_) << 4; 
+      r |= local_id_t(entity_) << (4 + PBITS);
+      return r;
     }
 
     size_t global_id() const


### PR DESCRIPTION
    - Squelch clang warnings
    - id_t cannot use reinterpret_cast to get local_id as this is
      not portable.